### PR TITLE
Get the link and style sources in the order they appear in the document.

### DIFF
--- a/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
+++ b/PreMailer.Net/PreMailer.Net.Tests/PreMailerTests.cs
@@ -470,6 +470,42 @@ namespace PreMailer.Net.Tests
 			Assert.Contains("<div class=\"test\" style=\"width: 150px\">", premailedOutput.Html);
 		}
 
+		/// <summary>
+		/// Select the style and link nodes in the order they appear in the document.
+		/// </summary>
+		[Fact]
+		public void ContainsLinkCssElement_DownloadsCss_InlinesContentWithLinkStyleOrder()
+		{
+			var mockDownloader = new Mock<IWebDownloader>();
+			mockDownloader.Setup(d => d.DownloadString(It.IsAny<Uri>())).Returns(".test { width: 150px; }");
+			WebDownloader.SharedDownloader = mockDownloader.Object;
+
+			string input = "<html><head><link href=\"http://a.com/b.css\"></link><style type=\"text/css\">.test { width: 100px; }</style></head><body><div class=\"test\">test</div></body></html>";
+
+			PreMailer sut = new PreMailer(input, new Uri("http://a.com"));
+			var premailedOutput = sut.MoveCssInline();
+
+			Assert.Contains("<div class=\"test\" style=\"width: 100px\">", premailedOutput.Html);
+		}
+
+		/// <summary>
+		/// Select the style and link nodes in the order they appear in the document.
+		/// </summary>
+		[Fact]
+		public void ContainsLinkCssElement_DownloadsCss_InlinesContentWithStyleLinkOrder()
+		{
+			var mockDownloader = new Mock<IWebDownloader>();
+			mockDownloader.Setup(d => d.DownloadString(It.IsAny<Uri>())).Returns(".test { width: 150px; }");
+			WebDownloader.SharedDownloader = mockDownloader.Object;
+
+			string input = "<html><head></link><style type=\"text/css\">.test { width: 100px; }</style><link href=\"http://a.com/b.css\"></head><body><div class=\"test\">test</div></body></html>";
+
+			PreMailer sut = new PreMailer(input, new Uri("http://a.com"));
+			var premailedOutput = sut.MoveCssInline();
+
+			Assert.Contains("<div class=\"test\" style=\"width: 150px\">", premailedOutput.Html);
+		}
+
 		[Fact]
 		public void ContainsKeyframeCSS_InlinesCSSWithOutError()
 		{

--- a/PreMailer.Net/PreMailer.Net/PreMailer.cs
+++ b/PreMailer.Net/PreMailer.Net/PreMailer.cs
@@ -154,17 +154,14 @@ namespace PreMailer.Net
 			_css = css;
 
 			// Gather all of the CSS that we can work with.
-			var cssSourceNodes = CssSourceNodes();
-			var cssLinkNodes = CssLinkNodes();
+			var cssSourceNodes = CssSourceNodesAll();
 			var cssSources = new List<ICssSource>(ConvertToStyleSources(cssSourceNodes));
-			cssSources.AddRange(ConvertToStyleSources(cssLinkNodes));
 
 			var cssBlocks = GetCssBlocks(cssSources);
 
 			if (_removeStyleElements)
 			{
 				RemoveStyleElements(cssSourceNodes, preserveMediaQueries);
-				RemoveStyleElements(cssLinkNodes);
 			}
 
 			var joinedBlocks = Join(cssBlocks);
@@ -287,6 +284,36 @@ namespace PreMailer.Net
 			}
 
 			return result;
+		}
+
+		private IEnumerable<IElement> CssSourceNodesAll()
+		{
+			IEnumerable<IElement> elements = _document.QuerySelectorAll("style,link");
+
+			if (!String.IsNullOrEmpty(_ignoreElements))
+			{
+				elements = elements.Not(_ignoreElements);
+			}
+
+			elements = elements.Where(elem =>
+			{
+				if (elem.NodeName == "STYLE")
+				{
+					var mediaAttribute = elem.GetAttribute("media");
+
+					return string.IsNullOrWhiteSpace(mediaAttribute) || CssParser.SupportedMediaQueriesRegex.IsMatch(mediaAttribute);
+				}
+				else
+				{
+					return elem.Attributes
+						.Any(a => a.Name.Equals("href", StringComparison.OrdinalIgnoreCase) &&
+								 (a.Value.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
+								 (elem.Attributes.Any(r => r.Name.Equals("rel", StringComparison.OrdinalIgnoreCase) &&
+														r.Value.Equals("stylesheet", StringComparison.OrdinalIgnoreCase)))));
+				}
+			});
+
+			return elements;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Get the link and style sources in the order they appear in the document instead of first the style nodes and then the link nodes.

Added two tests to PreMailerTests to check the order of the styles applied.